### PR TITLE
fix: wait for all workflows before reporting to coveralls

### DIFF
--- a/.github/workflows/adder.yaml
+++ b/.github/workflows/adder.yaml
@@ -29,12 +29,7 @@ jobs:
           COVERALLS_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           COVERALLS_PARALLEL: true
           COVERALLS_FLAG_NAME: 'Adder'
+          COVERALLS_JOB_ID: ${{ github.sha }}
         run: |
           go install github.com/mattn/goveralls@latest
           goveralls -coverprofile=coverage -service=github
-#  finish:
-#    needs: [test]
-#    runs-on: ubuntu-latest
-#    steps:
-#      - name: Coveralls Finished
-#        run: curl "https://coveralls.io/webhook?repo_token=${{ secrets.GITHUB_TOKEN }}&repo_name=${{ github.repository }}" -d "payload[build_num]=${{ github.run_id }}&payload[status]=done"

--- a/.github/workflows/adder.yaml
+++ b/.github/workflows/adder.yaml
@@ -29,7 +29,7 @@ jobs:
           COVERALLS_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           COVERALLS_PARALLEL: true
           COVERALLS_FLAG_NAME: 'Adder'
-          COVERALLS_JOB_ID: ${{ github.sha }}
+          COVERALLS_SERVICE_JOB_ID: ${{ github.sha }}
         run: |
           go install github.com/mattn/goveralls@latest
           goveralls -coverprofile=coverage -service=github

--- a/.github/workflows/coveralls.yaml
+++ b/.github/workflows/coveralls.yaml
@@ -1,0 +1,31 @@
+name: Coveralls report
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    paths:
+      - 'subber/**'
+      - 'adder/**'
+      - 'go.mod'
+
+jobs:
+  report:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Wait on tests
+        uses: lewagon/wait-on-check-action@v1.3.1
+        with:
+          ref: ${{ github.sha }}
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          wait-interval: 10 # seconds
+          running-workflow-name: report
+          allowed-conclusions: success,skipped,cancelled,failure
+
+      - uses: coverallsapp/github-action@master
+        env:
+          COVERALLS_SERVICE_NUMBER: ${{ github.sha }}
+          COVERALLS_SERVICE_JOB_ID: ${{ github.sha }}
+        with:
+          carryforward: "Subber,Adder"
+          parallel-finished: true

--- a/.github/workflows/coveralls.yaml
+++ b/.github/workflows/coveralls.yaml
@@ -13,7 +13,18 @@ jobs:
   report:
     runs-on: ubuntu-latest
     steps:
-      - name: Wait on tests
+      - name: Wait on tests (PR)
+        uses: lewagon/wait-on-check-action@v1.3.1
+        if: github.event_name == 'pull_request'
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          wait-interval: 10 # seconds
+          running-workflow-name: report
+          allowed-conclusions: success,skipped,cancelled,failure
+
+      - name: Wait on tests (push)
+        if: github.event_name != 'pull_request'
         uses: lewagon/wait-on-check-action@v1.3.1
         with:
           ref: ${{ github.sha }}

--- a/.github/workflows/subber.yaml
+++ b/.github/workflows/subber.yaml
@@ -29,7 +29,7 @@ jobs:
           COVERALLS_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           COVERALLS_PARALLEL: true
           COVERALLS_FLAG_NAME: 'Subber'
-          COVERALLS_JOB_ID: ${{ github.sha }}
+          COVERALLS_SERVICE_JOB_ID: ${{ github.sha }}
         run: |
           go install github.com/mattn/goveralls@latest
           goveralls -coverprofile=coverage -service=github

--- a/.github/workflows/subber.yaml
+++ b/.github/workflows/subber.yaml
@@ -29,6 +29,7 @@ jobs:
           COVERALLS_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           COVERALLS_PARALLEL: true
           COVERALLS_FLAG_NAME: 'Subber'
+          COVERALLS_JOB_ID: ${{ github.sha }}
         run: |
           go install github.com/mattn/goveralls@latest
           goveralls -coverprofile=coverage -service=github

--- a/adder/adder.go
+++ b/adder/adder.go
@@ -4,7 +4,6 @@ func Add(x, y int) int {
 	return x + y
 }
 
-// comment23
 func CheckValues(x, y int) string {
 	sum := x + y
 	if sum > 10 {

--- a/subber/subber.go
+++ b/subber/subber.go
@@ -4,7 +4,6 @@ func Sub(x, y int) int {
 	return x - y
 }
 
-// comment23
 func CheckSub(x, y int) string {
 	sum := x - y
 	if sum > 0 {


### PR DESCRIPTION
**Summary**

Here is an example of how to use coveralls reports with carryforwarding for many workflows setup.

1. Use parallel reports for each workflow (already done)
2. Use a separate workflow for coverage reporting
3. Use `lewagon/wait-on-check-action` to wait for all other workflows to complete
4. Pass all job flags to `carryforward` parameter